### PR TITLE
Fix of github URL for composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "brave-sir-robin/amqphp",
     "description": "AMQP 0.9.1 Protocol Implementation in pure PHP",
     "keywords": ["AMQPHP","AMQP", "RabbitMQ"],
-    "homepage": "http://github.com/BraveSirRobin/amqphp",
+    "homepage": "https://github.com/BraveSirRobin/amqphp/",
     "type": "library",
     "license": "LGPL",
     "authors": [


### PR DESCRIPTION
Without using https:// github requests authentication using keys.
